### PR TITLE
Map control key to command key on Mac

### DIFF
--- a/Editor/src/com/kotcrab/vis/editor/module/editor/EditingSettingsModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/editor/EditingSettingsModule.java
@@ -19,6 +19,7 @@ package com.kotcrab.vis.editor.module.editor;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.esotericsoftware.kryo.serializers.TaggedFieldSerializer.Tag;
 import com.google.common.eventbus.Subscribe;
 import com.kotcrab.vis.editor.App;
@@ -70,7 +71,7 @@ public class EditingSettingsModule extends EditorModule {
 
 	public boolean isSnapEnabledOrKeyPressed () {
 		boolean snap = config.snapToGrid;
-		if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) snap = !snap; //allow to override snap setting
+		if (UIUtils.ctrl()) snap = !snap; //allow to override snap setting
 		return snap;
 	}
 
@@ -81,7 +82,7 @@ public class EditingSettingsModule extends EditorModule {
 	private class EditingInputListener extends ModalInputListener {
 		@Override
 		public boolean keyDown (InputEvent event, int keycode) {
-			if (Gdx.input.isKeyPressed(Keys.SHIFT_LEFT) && keycode == Keys.NUM_5) {
+			if (UIUtils.shift() && keycode == Keys.NUM_5) {
 				App.eventBus.post(new ToggleToolbarEvent(ToolbarEventType.GRID_SNAP_SETTING_CHANGED, !isSnapToGrid()));
 				return true;
 			}

--- a/Editor/src/com/kotcrab/vis/editor/module/project/ExportersManagerModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/project/ExportersManagerModule.java
@@ -19,6 +19,7 @@ package com.kotcrab.vis.editor.module.project;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.kotcrab.vis.editor.module.InjectModule;
 import com.kotcrab.vis.editor.module.editor.ExtensionStorageModule;
@@ -69,7 +70,7 @@ public class ExportersManagerModule extends ProjectModule {
 	private class ExportInputListener extends ModalInputListener {
 		@Override
 		public boolean keyDown (InputEvent event, int keycode) {
-			if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT) && keycode == Keys.E) {
+			if (UIUtils.ctrl() && keycode == Keys.E) {
 				export(false);
 				return true;
 			}

--- a/Editor/src/com/kotcrab/vis/editor/module/project/assetsmanager/AssetsUIModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/project/assetsmanager/AssetsUIModule.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.Tree.Node;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.ObjectMap;
@@ -573,7 +574,7 @@ public class AssetsUIModule extends ProjectModule implements WatchListener, VisT
 	}
 
 	private void selectItem (FileItem fileItem, boolean rightClick) {
-		if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT) == false) {
+		if (UIUtils.ctrl() == false) {
 			if (rightClick) {
 				if (selectedFiles.contains(fileItem, true) == false)
 					clearSelection();

--- a/Editor/src/com/kotcrab/vis/editor/module/scene/UndoModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/scene/UndoModule.java
@@ -19,6 +19,7 @@ package com.kotcrab.vis.editor.module.scene;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Array;
 import com.kotcrab.vis.editor.App;
 import com.kotcrab.vis.editor.event.RedoEvent;
@@ -111,7 +112,7 @@ public class UndoModule extends SceneModule {
 		@Override
 		public boolean keyDown (InputEvent event, int keycode) {
 			if (tabActive) {
-				if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) {
+				if (UIUtils.ctrl()) {
 					if (keycode == Keys.Z) undo();
 					if (keycode == Keys.Y) redo();
 

--- a/Editor/src/com/kotcrab/vis/editor/module/scene/entitymanipulator/EntityManipulatorModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/scene/entitymanipulator/EntityManipulatorModule.java
@@ -27,9 +27,11 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop.Payload;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.ObjectSet;
@@ -701,8 +703,8 @@ public class EntityManipulatorModule extends SceneModule {
 
 		if (button == Buttons.RIGHT && mouseDragged == false) {
 			if (selectedEntities.size > 0) {
-				menuX = x;
-				menuY = y;
+				menuX = camera.getInputX();
+				menuY = camera.getInputY();
 
 				buildEntityPopupMenu(selectedEntities);
 				entityPopupMenu.showMenu(event.getStage(), event.getStageX(), event.getStageY());
@@ -748,7 +750,7 @@ public class EntityManipulatorModule extends SceneModule {
 				return true;
 			}
 
-			if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT) && keycode == Keys.S) sceneTab.save();
+			if (UIUtils.ctrl() && keycode == Keys.S) sceneTab.save();
 			if (keycode == Keys.F1) {
 				switchTool(selectionTool);
 				App.eventBus.post(new ToolSwitchedEvent(Tools.SELECTION_TOOL));
@@ -758,7 +760,7 @@ public class EntityManipulatorModule extends SceneModule {
 				App.eventBus.post(new ToolSwitchedEvent(Tools.POLYGON_TOOL));
 			}
 
-			if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) {
+			if (UIUtils.ctrl()) {
 				if (keycode == Keys.A) selectAll();
 				if (keycode == Keys.C) copy();
 				if (keycode == Keys.V) paste();
@@ -771,8 +773,8 @@ public class EntityManipulatorModule extends SceneModule {
 				zIndexManipulator.moveSelectedEntities(getSelectedEntities(), false);
 
 			float delta = 10;
-			if (Gdx.input.isKeyPressed(Keys.SHIFT_LEFT)) delta *= 10;
-			if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) delta *= 10;
+			if (UIUtils.shift()) delta *= 10;
+			if (UIUtils.ctrl()) delta *= 10;
 
 			delta = delta / scene.pixelsPerUnit;
 

--- a/Editor/src/com/kotcrab/vis/editor/module/scene/entitymanipulator/tool/BaseSelectionTool.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/scene/entitymanipulator/tool/BaseSelectionTool.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Array;
 import com.kotcrab.vis.editor.module.scene.action.MoveEntityAction;
 import com.kotcrab.vis.editor.module.scene.entitymanipulator.RectangularSelection;
@@ -75,7 +76,7 @@ public abstract class BaseSelectionTool extends Tool {
 				mouseInsideSelected = true;
 
 				//multiple select made easy
-				if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT) == false) entityManipulator.resetSelection();
+				if (UIUtils.ctrl() == false) entityManipulator.resetSelection();
 
 				EntityProxy result = findEntityWithSmallestSurfaceArea(x, y);
 				if (result != null && entityManipulator.isSelected(result) == false)
@@ -111,7 +112,7 @@ public abstract class BaseSelectionTool extends Tool {
 
 		if (button == Buttons.RIGHT && cameraDragged == false) {
 			if (isMouseInsideSelectedEntities(x, y) == false)
-				if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT) == false) entityManipulator.resetSelection();
+				if (UIUtils.ctrl() == false) entityManipulator.resetSelection();
 
 			EntityProxy result = findEntityWithSmallestSurfaceArea(x, y);
 			if (result != null && entityManipulator.isSelected(result) == false)

--- a/Editor/src/com/kotcrab/vis/editor/ui/scene/entityproperties/NumberInputField.java
+++ b/Editor/src/com/kotcrab/vis/editor/ui/scene/entityproperties/NumberInputField.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.FocusListener;
 import com.badlogic.gdx.utils.Timer;
@@ -29,6 +30,7 @@ import com.badlogic.gdx.utils.Timer.Task;
 import com.kotcrab.vis.ui.InputValidator;
 import com.kotcrab.vis.ui.widget.VisTextField;
 import com.kotcrab.vis.ui.widget.VisValidableTextField;
+
 import org.apache.commons.lang3.StringUtils;
 
 import static com.kotcrab.vis.editor.util.NumberUtils.floatToString;
@@ -102,7 +104,7 @@ public class NumberInputField extends VisValidableTextField {
 
 		@Override
 		public boolean keyTyped (InputEvent event, char character) {
-			if (character == '-' && Gdx.input.isKeyPressed(Keys.SHIFT_LEFT)) return false;
+			if (character == '-' && UIUtils.shift()) return false;
 			return super.keyTyped(event, character);
 		}
 
@@ -111,8 +113,8 @@ public class NumberInputField extends VisValidableTextField {
 			repeatTask.cancel();
 
 			int delta = 0;
-			if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) delta = 1;
-			if (Gdx.input.isKeyPressed(Keys.SHIFT_LEFT)) delta = 10;
+			if (UIUtils.ctrl()) delta = 1;
+			if (UIUtils.shift()) delta = 10;
 
 			if (delta != 0) {
 				if (keycode == Keys.MINUS) {

--- a/UI/src/com/kotcrab/vis/ui/widget/VisTextArea.java
+++ b/UI/src/com/kotcrab/vis/ui/widget/VisTextArea.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.Pool;
@@ -393,7 +394,7 @@ public class VisTextArea extends VisTextField {
 			Stage stage = getStage();
 			if (stage != null && stage.getKeyboardFocus() == VisTextArea.this) {
 				boolean repeat = false;
-				boolean shift = Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT) || Gdx.input.isKeyPressed(Input.Keys.SHIFT_RIGHT);
+				boolean shift = UIUtils.shift();
 				if (keycode == Input.Keys.DOWN) {
 					if (shift) {
 						if (!hasSelection) {

--- a/UI/src/com/kotcrab/vis/ui/widget/color/ColorInputField.java
+++ b/UI/src/com/kotcrab/vis/ui/widget/color/ColorInputField.java
@@ -23,6 +23,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.FocusListener;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.kotcrab.vis.ui.InputValidator;
 import com.kotcrab.vis.ui.widget.VisTextField;
 import com.kotcrab.vis.ui.widget.VisValidableTextField;
@@ -57,8 +58,8 @@ public class ColorInputField extends VisValidableTextField {
 			@Override
 			public boolean keyTyped (InputEvent event, char character) {
 				ColorInputField field = (ColorInputField) event.getListenerActor();
-				if (character == '+') field.changeValue(Gdx.input.isKeyPressed(Keys.SHIFT_LEFT) ? 10 : 1);
-				if (character == '-') field.changeValue(Gdx.input.isKeyPressed(Keys.SHIFT_LEFT) ? -10 : -1);
+				if (character == '+') field.changeValue(UIUtils.shift() ? 10 : 1);
+				if (character == '-') field.changeValue(UIUtils.shift() ? -10 : -1);
 
 				if (character != 0) listener.changed(getValue());
 

--- a/UI/src/com/kotcrab/vis/ui/widget/file/FileChooser.java
+++ b/UI/src/com/kotcrab/vis/ui/widget/file/FileChooser.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Value;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.I18NBundle;
 import com.kotcrab.vis.ui.Sizes;
@@ -202,7 +203,7 @@ public class FileChooser extends VisWindow {
 		addListener(new InputListener() {
 			@Override
 			public boolean keyDown (InputEvent event, int keycode) {
-				if (keycode == Keys.A && Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) {
+				if (keycode == Keys.A && UIUtils.ctrl()) {
 					selectAll();
 					return true;
 				}


### PR DESCRIPTION
Replaces all ```isKeyDown(Keys.CONTROL_LEFT)``` with ```UIUtils.ctrl()```.
Also replaces all ```isKeyDown(Keys.SHIFT_LEFT)``` with ```UIUtils.shift()```.
https://github.com/kotcrab/VisEditor/blob/master/UI/src/com/kotcrab/vis/ui/widget/VisProgressBar.java#L221 and https://github.com/kotcrab/VisEditor/blob/master/UI/src/com/kotcrab/vis/ui/widget/file/FileChooser.java#L66-L67 weren't changed, because I don't really know what that should do.