### PR TITLE
Add AssetsUIModule#highlightDir(), this fixes "Open Exisiting Scene" link, so that the scene directory is selected.

### DIFF
--- a/Editor/CHANGES
+++ b/Editor/CHANGES
@@ -5,6 +5,7 @@
 -Fixed "Auto Set Origin to Center" checkbox not updating EntityProperties UI after checking
 -Fixed "Auto Adjust Origin" in PhysicsPropertiesComponent for scaled objects
 -Fixed copy-paste at wrong position when using right click popup menu
+-Fixed "Open Existing Scene" link, now the scene directory is also selected
 -"Add Component" dialog now can be used for multiple selected entities
 -Improved Twitter view
 

--- a/Editor/src/com/kotcrab/vis/editor/module/project/assetsmanager/AssetsUIModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/project/assetsmanager/AssetsUIModule.java
@@ -165,6 +165,23 @@ public class AssetsUIModule extends ProjectModule implements WatchListener, VisT
 
 		return false;
 	}
+	
+	private boolean highlightDir(FileHandle fileHandle){
+		Array<Node> allNodes = contentTree.getNodes();
+		for(Node node: allNodes){
+			if(((FolderItem)node.getActor()).getFile().equals(fileHandle)){
+				contentTree.getSelection().choose(node);
+				return true;
+			}
+			
+			if (node.getChildren().size > 0) {
+				node.setExpanded(true);
+				if (highlightCurrentDir(node.getChildren())) return true;
+				node.setExpanded(false);
+			}
+		}
+		return false;
+	}
 
 	private void initModule () {
 		visFolder = fileAccess.getVisFolder();
@@ -324,6 +341,7 @@ public class AssetsUIModule extends ProjectModule implements WatchListener, VisT
 
 		String currentPath = directory.path().substring(visFolder.path().length() + 1);
 		contentTitleLabel.setText("Content [" + currentPath + "]");
+		highlightDir(directory);
 	}
 
 	public FileHandle getCurrentDirectory () {


### PR DESCRIPTION
We now have highlightCurrentDir(Array<Node) and hilightDir(FileHandle).
One of those methods has to die ^^