### PR TITLE
Fix particle texture missing crash

### DIFF
--- a/Editor/src/com/kotcrab/vis/editor/module/project/ParticleCacheModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/project/ParticleCacheModule.java
@@ -18,7 +18,6 @@ package com.kotcrab.vis.editor.module.project;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.ParticleEffect;
-import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.kotcrab.vis.editor.App;
 import com.kotcrab.vis.editor.event.ResourceReloadedEvent;

--- a/Editor/src/com/kotcrab/vis/editor/module/project/ParticleCacheModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/project/ParticleCacheModule.java
@@ -18,6 +18,8 @@ package com.kotcrab.vis.editor.module.project;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.ParticleEffect;
+import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.kotcrab.vis.editor.App;
 import com.kotcrab.vis.editor.event.ResourceReloadedEvent;
 import com.kotcrab.vis.editor.util.DirectoryWatcher.WatchListener;
@@ -48,7 +50,15 @@ public class ParticleCacheModule extends ProjectModule implements WatchListener 
 
 	private ParticleEffect get (FileHandle file, float scaleFactor) {
 		ParticleEffect effect = new ParticleEffect();
-		effect.load(file, file.parent());
+
+		try {
+			effect.load(file, file.parent());
+		}
+		catch (GdxRuntimeException error) {
+			error.printStackTrace();
+			return null;
+		}
+
 		effect.scaleEffect(scaleFactor);
 		return effect;
 	}

--- a/Editor/src/com/kotcrab/vis/editor/module/scene/entitymanipulator/EntityManipulatorModule.java
+++ b/Editor/src/com/kotcrab/vis/editor/module/scene/entitymanipulator/EntityManipulatorModule.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.ParticleEffect;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
 import com.badlogic.gdx.math.MathUtils;
@@ -458,12 +459,20 @@ public class EntityManipulatorModule extends SceneModule {
 
 			if (asset.getPath().startsWith("particle/")) {
 				float scale = 1f / scene.pixelsPerUnit;
-				entity = new EntityBuilder(entityEngine)
-						.with(new ParticleComponent(particleCache.get(asset, scale)), new PixelsPerUnitComponent(scene.pixelsPerUnit),
-								new AssetComponent(asset),
-								new RenderableComponent(0), new LayerComponent(scene.getActiveLayerId()),
-								new ExporterDropsComponent(PixelsPerUnitComponent.class))
-						.build();
+
+				ParticleEffect particleEffect = particleCache.get(asset, scale);
+				if (particleEffect != null) {
+					entity = new EntityBuilder(entityEngine)
+							.with(new ParticleComponent(particleEffect), new PixelsPerUnitComponent(scene.pixelsPerUnit),
+									new AssetComponent(asset),
+									new RenderableComponent(0), new LayerComponent(scene.getActiveLayerId()),
+									new ExporterDropsComponent(PixelsPerUnitComponent.class))
+							.build();
+				}
+				else {
+					statusBar.setText("Particle system cannot be created. Probably, particle texture is missing.");
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
I tried to fix #66 issue. 

I think it will better, to use some dialog to inform user about problem with particles. But I'm not sure how it is should be implemented.

Also, if particle texture will be removed after saving scene wich uses particles with this texture, is not to be able to open this scene. But this case is not handled in all inflater systems. 

P.S. Sorry, I'm forgot to specify issue number in commit message.