### PR TITLE
GWT and DragPane fixes

### DIFF
--- a/UI/src/com/kotcrab/vis/ui/layout/DragPane.java
+++ b/UI/src/com/kotcrab/vis/ui/layout/DragPane.java
@@ -604,7 +604,7 @@ public class DragPane extends Container<WidgetGroup> {
 		}
 
 		/**
-		 * Limits {@link DragPane} children amount to a certain number.
+		 * Limits {@link DragPane} children amount to a certain number. Never rejects own children.
 		 * @author MJ
 		 * @since 0.9.3
 		 */
@@ -621,7 +621,7 @@ public class DragPane extends Container<WidgetGroup> {
 
 			@Override
 			public boolean accept (final DragPane dragPane, final Actor actor) {
-				return dragPane.getChildren().size < max;
+				return dragPane.contains(actor) || dragPane.getChildren().size < max;
 			}
 		}
 	}

--- a/UI/src/com/kotcrab/vis/ui/util/adapter/SimpleListAdapter.java
+++ b/UI/src/com/kotcrab/vis/ui/util/adapter/SimpleListAdapter.java
@@ -62,7 +62,7 @@ public class SimpleListAdapter<ItemT> extends ArrayAdapter<ItemT, VisTable> {
 		view.setBackground(style.background);
 	}
 
-	private static class SimpleListAdapterStyle {
+	public static class SimpleListAdapterStyle {
 		public Drawable background;
 		public Drawable selection;
 

--- a/UI/src/com/kotcrab/vis/vis-ui.gwt.xml
+++ b/UI/src/com/kotcrab/vis/vis-ui.gwt.xml
@@ -69,4 +69,5 @@
 
 	<extend-configuration-property name="gdx.reflect.exclude" value="com.kotcrab.vis.ui.widget.file" />
 	<extend-configuration-property name="gdx.reflect.include" value="com.kotcrab.vis.ui.widget.file.FileChooserStyle" />
+	<extend-configuration-property name="gdx.reflect.include" value="com.kotcrab.vis.ui.util.adapter.SimpleListAdapter" />
 </module>


### PR DESCRIPTION
`SimpleListAdapterStyle` must be public and included in GWT reflection.

`LimitChildren` listener now never rejects own children, even when max children amount is achieved.